### PR TITLE
Fix Broken Logic for Empty Regions

### DIFF
--- a/PrettyYaml.py
+++ b/PrettyYaml.py
@@ -17,7 +17,7 @@ class PrettyyamlCommand(sublime_plugin.TextCommand):
 
             selected_entire_file = False
             if region.empty() and len(regions) > 1:
-                return
+                continue
             elif region.empty() and s.get("use_entire_file_if_no_selection", True):
                 selection = sublime.Region(0, view.size())
                 selected_entire_file = True

--- a/PrettyYaml.py
+++ b/PrettyYaml.py
@@ -12,13 +12,14 @@ class PrettyyamlCommand(sublime_plugin.TextCommand):
 
     def run(self, edit):
         """ Pretty print YAML """
-        for region in self.view.sel():
+        regions = self.view.sel()
+        for region in regions:
 
             selected_entire_file = False
-
-            # If no selection, use the entire file as the selection
-            if region.empty() and s.get("use_entire_file_if_no_selection", True):
-                selection = sublime.Region(0, self.view.size())
+            if region.empty() and len(regions) > 1:
+                return
+            elif region.empty() and s.get("use_entire_file_if_no_selection", True):
+                selection = sublime.Region(0, view.size())
                 selected_entire_file = True
             else:
                 selection = region

--- a/PrettyYaml.py
+++ b/PrettyYaml.py
@@ -19,7 +19,7 @@ class PrettyyamlCommand(sublime_plugin.TextCommand):
             if region.empty() and len(regions) > 1:
                 continue
             elif region.empty() and s.get("use_entire_file_if_no_selection", True):
-                selection = sublime.Region(0, view.size())
+                selection = sublime.Region(0, self.view.size())
                 selected_entire_file = True
             else:
                 selection = region


### PR DESCRIPTION
Currently, if you have multiple regions selected, and one of them is empty, we try to format the entire document, which is clearly wrong. This fixes it by check if the region is empty and if there is only one region.